### PR TITLE
More hooks

### DIFF
--- a/ArmaVR/dxgi/abi.cpp
+++ b/ArmaVR/dxgi/abi.cpp
@@ -59,3 +59,29 @@ void armavr::dxgi::addresses::ID3D11DeviceContext1::set_ClearView(::ID3D11Device
     deviceContext->lpVtbl->ClearView = addr;
     VirtualProtect(&deviceContext->lpVtbl->ClearView, sizeof(void*), original_protect, &original_protect);
 }
+
+armavr::dxgi::addresses::ID3D11DeviceContext1::OMSetRenderTargets armavr::dxgi::addresses::ID3D11DeviceContext1::get_OMSetRenderTargets(::ID3D11DeviceContext1* pDeviceContext)
+{
+    return reinterpret_cast<OMSetRenderTargets>(pDeviceContext->lpVtbl->OMSetRenderTargets);
+}
+
+void armavr::dxgi::addresses::ID3D11DeviceContext1::set_OMSetRenderTargets(::ID3D11DeviceContext1* pDeviceContext, OMSetRenderTargets addr)
+{
+    DWORD original_protect;
+    VirtualProtect(&pDeviceContext->lpVtbl->OMSetRenderTargets, sizeof(void*), PAGE_EXECUTE_READWRITE, &original_protect);
+    pDeviceContext->lpVtbl->OMSetRenderTargets = addr;
+    VirtualProtect(&pDeviceContext->lpVtbl->OMSetRenderTargets, sizeof(void*), original_protect, &original_protect);
+}
+
+armavr::dxgi::addresses::ID3D11Device::CreateRenderTargetView armavr::dxgi::addresses::ID3D11Device::get_CreateRenderTargetView(::ID3D11Device* pDevice)
+{
+    return reinterpret_cast<CreateRenderTargetView>(pDevice->lpVtbl->CreateRenderTargetView);
+}
+
+void armavr::dxgi::addresses::ID3D11Device::set_CreateRenderTargetView(::ID3D11Device* pDevice, CreateRenderTargetView addr)
+{
+    DWORD original_protect;
+    VirtualProtect(&pDevice->lpVtbl->CreateRenderTargetView, sizeof(void*), PAGE_EXECUTE_READWRITE, &original_protect);
+    pDevice->lpVtbl->CreateRenderTargetView = addr;
+    VirtualProtect(&pDevice->lpVtbl->CreateRenderTargetView, sizeof(void*), original_protect, &original_protect);
+}

--- a/ArmaVR/dxgi/abi.hpp
+++ b/ArmaVR/dxgi/abi.hpp
@@ -8,6 +8,9 @@ struct ID3D11RenderTargetView;
 struct ID3D11DepthStencilView;
 struct ID3D11DeviceContext1;
 struct ID3D11View;
+struct ID3D11Resource;
+struct D3D11_RENDER_TARGET_VIEW_DESC;
+struct ID3D11Device;
 
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <Windows.h>
@@ -61,5 +64,24 @@ namespace armavr::dxgi::addresses
             UINT NumRects);
         [[nodiscard]] armavr::dxgi::addresses::ID3D11DeviceContext1::ClearView get_ClearView(::ID3D11DeviceContext1* pDeviceContext);
         void set_ClearView(::ID3D11DeviceContext1* pDeviceContext, ClearView addr);
+
+        typedef void (STDMETHODCALLTYPE* OMSetRenderTargets)(
+            ::ID3D11DeviceContext1* This,
+            UINT                   NumViews,
+            ID3D11RenderTargetView * const *ppRenderTargetViews,
+            ID3D11DepthStencilView *pDepthStencilView);
+        [[nodiscard]] armavr::dxgi::addresses::ID3D11DeviceContext1::OMSetRenderTargets get_OMSetRenderTargets(::ID3D11DeviceContext1* pDeviceContext);
+        void set_OMSetRenderTargets(::ID3D11DeviceContext1* pDeviceContext, OMSetRenderTargets addr);
+    }
+    namespace ID3D11Device
+    {
+        typedef HRESULT (STDMETHODCALLTYPE* CreateRenderTargetView)(
+            ::ID3D11Device                      *This,
+            ID3D11Resource                      *pResource,
+            const D3D11_RENDER_TARGET_VIEW_DESC *pDesc,
+            ID3D11RenderTargetView              **ppRTView
+        );
+        [[nodiscard]] armavr::dxgi::addresses::ID3D11Device::CreateRenderTargetView get_CreateRenderTargetView(::ID3D11Device* pDevice);
+        void set_CreateRenderTargetView(::ID3D11Device* pDevice, CreateRenderTargetView addr);
     }
 }

--- a/ArmaVR/dxgi/swapchain.hpp
+++ b/ArmaVR/dxgi/swapchain.hpp
@@ -10,6 +10,8 @@ class DXGISwapChainLayer : public IDXGISwapChain
     ID3D11Device* m_device;
     ID3D11DeviceContext* m_device_context;
 
+    void* m_swapchain_back_buffer;
+
 public:
 
     DXGISwapChainLayer(IDXGISwapChain* swap);


### PR DESCRIPTION
Capture Swapchain BackBuffer
Capture creation of backbuffer RenderTargetView
Filter OMSetRenderTargets on captured RenderTargetView
Print Present and OMSetRenderTargets